### PR TITLE
Add TILs

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -17,6 +17,7 @@ root: true
 rules:
   '@typescript-eslint/no-var-requires': off # give me longer to write new code before distracting me with errors
   '@typescript-eslint/triple-slash-reference': off # disable since astro automatically uses these
+  dot-notation: 'error' # enforce dot notation instead of square brackets whenever possible
 
 overrides:
   # Define the configuration for `.astro` file.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,9 +4,11 @@ import site from '../data/site'
 import { isPathnameInCollection } from '../utils/collections'
 import { getPosts } from '../utils/posts'
 import { getNotes } from '../utils/notes'
+import { getTILs } from '../utils/tils'
 
 const posts = await getPosts()
 const notes = await getNotes()
+const tils = await getTILs()
 
 const { pathname } = Astro.url
 
@@ -14,7 +16,8 @@ const { pathname } = Astro.url
 const isCurrentPage = (item: NavItem): boolean =>
   item.url === pathname ||
   (isPathnameInCollection(pathname, posts) && item.url === '/') ||
-  (isPathnameInCollection(pathname, notes) && item.url === '/notes/')
+  (isPathnameInCollection(pathname, notes) && item.url === '/notes/') ||
+  (isPathnameInCollection(pathname, tils) && item.url === '/til/')
 ---
 
 <header class="mb-12">

--- a/src/data/nav.ts
+++ b/src/data/nav.ts
@@ -6,6 +6,7 @@ export type NavItem = {
 export default {
   top: [
     { title: 'writing', url: '/' },
+    { title: 'til', url: '/til/' },
     { title: 'notes', url: '/notes/' },
     { title: 'about', url: '/about/' },
     { title: 'likes', url: '/likes/' },

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -1,15 +1,17 @@
 ---
 import Writing from '../layouts/Writing.astro'
+import { getTILs } from '../utils/tils'
 import { getNotes } from '../utils/notes'
 import { getDrafts, getPosts } from '../utils/posts'
 
 export async function getStaticPaths() {
   const posts = await getPosts()
+  const tils = await getTILs()
   const notes = await getNotes()
   const drafts = await getDrafts()
 
   // Generate a path for each writing collection entry
-  return [...posts, ...notes, ...drafts].map(entry => ({
+  return [...posts, ...tils, ...notes, ...drafts].map(entry => ({
     params: { slug: entry.slug },
     props: { entry },
   }))

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,6 +21,19 @@ const isScheduled = (post: Post | Draft): boolean => post.data.date && Date.pars
     <ol reversed class="columns-xl gap-x-24">
       {
         [...drafts, ...posts].map(post => {
+          // TODO: my goal is to group the posts under a heading for each topic (tag) or perhaps the even-higher level category
+          // (e.g. Languages, Frameworks, etc) so I can do the same on the notes page and start publishing small notes quickly
+          // without worrying about nesting them hierarchically or inserting them into a topic note. All hidden "drafts" could
+          // just be immediately published as rough note outlines which I can expand on later if worthwhile. Otherwise, a quick
+          // blurb and a few links would be enough to share the idea in a way that would be helpful to future me, at the very least.
+          // TODO: read a "category" property instead of the first tag?
+          // const primaryTag =
+          //   (post.data.tags ?? ['untagged'])
+          //     .filter(tag => tag !== 'post')
+          //     .map(tag => tag.replace('topic/', ''))
+          //     .at(0) ?? 'untagged'
+          // console.log('primaryTag:', primaryTag)
+
           const date = post.data.date || Date.now()
 
           return (

--- a/src/pages/notes.astro
+++ b/src/pages/notes.astro
@@ -12,6 +12,18 @@ const notes = await getNestedNotes()
   <section>
     <h2 class="sr-only">Topics</h2>
 
+    <!-- <ul>
+      {
+        notes.map(note => (
+          <li class="mb-2">
+            <a href={`/${note.slug}/`} class="link">
+              {String(note.data.title || note.slug).toLowerCase()}
+            </a>
+          </li>
+        ))
+      }
+    </ul> -->
+
     <ul class="list-notes">
       {
         notes.map(note => {

--- a/src/pages/til.astro
+++ b/src/pages/til.astro
@@ -1,0 +1,40 @@
+---
+import site from '../data/site'
+import Main from '../layouts/Main.astro'
+import { getHumanReadableDate, getMachineReadableDate } from '../utils/dates'
+import { getTILs } from '../utils/tils'
+
+const tils = await getTILs()
+---
+
+<Main title={site.title} description={site.description.site}>
+  <h1 class="sr-only">{site.title}</h1>
+
+  <section>
+    <h2 class="sr-only">TIL - Today I Learned</h2>
+
+    <ol reversed class="mx-auto max-w-2xl">
+      {
+        tils.map(til => {
+          const date = til.data.date || Date.now()
+
+          return (
+            <li class="mb-16">
+              <a href={`/${til.slug}/`} class="link-heading heading text-2xl">
+                {til.data.title || til.slug}
+              </a>
+
+              <time datetime={getMachineReadableDate(date)} class="timestamp block mt-2 md:min-w-[7rem]">
+                {getHumanReadableDate(date)}
+              </time>
+
+              <div class="markdown pt-2">
+                <til.Content />
+              </div>
+            </li>
+          )
+        })
+      }
+    </ol>
+  </section>
+</Main>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -23,6 +23,10 @@
 }
 
 @layer utilities {
+  .decoration-bright {
+    @apply decoration-white;
+  }
+
   .text-bright {
     @apply text-white;
   }
@@ -64,6 +68,19 @@
       &:active {
         @apply text-black;
       }
+    }
+  }
+
+  .link-heading {
+    @apply box-decoration-clone underline;
+    @apply underline-offset-[0.2em] decoration-[0.1em] decoration-[--moonlight-red-translucent] text-[--moonlight-red];
+
+    text-decoration-skip-ink: none;
+
+    &:hover,
+    &:focus,
+    &:active {
+      @apply outline-none decoration-bright text-bright;
     }
   }
 }

--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -1,12 +1,13 @@
 import type { CollectionEntry } from 'astro:content'
 
 export type Draft = CollectionEntry<'drafts'>
+export type TIL = CollectionEntry<'til'>
 export type Writing = CollectionEntry<'writing'>
 
 /**
  * Returns true if the pathname matches any slug in the collection (at any ancestry level)
  */
-export const isPathnameInCollection = (pathname: string, collection: Writing[] | Draft[]): boolean => {
+export const isPathnameInCollection = (pathname: string, collection: Writing[] | Draft[] | TIL[]): boolean => {
   const pathnameMatchesSlug = (slug: string): boolean => pathname === `/${slug}/`
 
   return collection.some(

--- a/src/utils/tils.ts
+++ b/src/utils/tils.ts
@@ -1,0 +1,53 @@
+import { getCollection } from 'astro:content'
+
+import type { Draft, TIL } from './collections'
+
+type TILWithContent = TIL & { Content: AstroComponentFactory; headings: MarkdownHeading[] }
+type TILWithDate = TIL & { data: { date: string } }
+
+export const isTIL = (til: TIL): til is TIL => til.data.tags?.includes('til')
+
+/**
+ * Returns true if TIL is published.
+ */
+const isPublished = (til: TIL): til is TILWithDate =>
+  isTIL(til) && til.data.date && Date.parse(til.data.date) <= Date.now()
+
+/**
+ * Sorts two TILs in descending order by publish date (or the current date if either TIL has no date yet).
+ */
+const sortByDate = (a: TIL | Draft, b: TIL | Draft): number =>
+  (Date.parse(b.data.date) || Date.now()).toString().localeCompare((Date.parse(a.data.date) || Date.now()).toString())
+
+/**
+ * Returns TILs sorted in descending order by publish date.
+ */
+const sortTILs = (tils: TIL[]): TILWithDate[] => tils.sort(sortByDate)
+
+import { getEntry } from 'astro:content'
+import type { MarkdownHeading } from 'astro'
+import type { AstroComponentFactory } from 'astro/dist/runtime/server'
+
+/**
+ * Returns all published TILs, in descending order by date (useful for RSS feed).
+ */
+export const getPublishedTILs = async (): Promise<TILWithDate[]> => sortTILs(await getCollection('til', isPublished))
+
+/**
+ * Returns all TILs in development and only published posts in production, in descending order by date.
+ */
+export const getTILs = async (): Promise<TILWithContent[]> => {
+  const tilProperties = await getCollection('til', til => (import.meta.env.PROD ? isPublished(til) : isTIL(til)))
+
+  const tilsWithContent: TILWithContent[] = await Promise.all(
+    tilProperties.map(async til => {
+      const entry = await getEntry('til', til.slug)
+      const { Content, headings } = await entry!.render() // TODO: make safer
+      return { ...til, Content, headings }
+    }),
+  )
+
+  return tilsWithContent.sort(sortByDate)
+
+  // return sortTILs(tilsWithContent)
+}


### PR DESCRIPTION
## What

- Adds a new `/til` route for very short, less-polished bits of learning

## Why

- I'm learning a lot every day, but rarely recording what I learn even though I want to
- I think perfectionism (aiming for consistent structure, polished explanations, etc) is adding too much friction and trying to make writing easier by suggesting templates to myself is just making writing more of a chore
- These introduce a quick, blank page, 5 minute lane I can publish ideas too without worrying about wording them just write or padding them with context or explanations of their value
- Just the facts and I'm outtie

## Inspiration

- https://github.com/jbranchaud/til
- https://jvns.ca/til/
- https://til.simonwillison.net