### PR TITLE
Notes cleanup and prerendering

### DIFF
--- a/src/actions/filterNotes/generateNotesPageHtml.ts
+++ b/src/actions/filterNotes/generateNotesPageHtml.ts
@@ -4,8 +4,8 @@ export const generateTagCloudItemHtml = (
   tagsInAllEntries: string[],
 ): string => {
   const colors = {
-    active: 'bg-[--moonlight-red] text-zinc-950 cursor-pointer',
-    inactive: 'bg-zinc-950 hover:bg-[--moonlight-red] text-[--moonlight-red] hover:text-zinc-950 cursor-pointer',
+    active: 'bg-[--moonlight-red] hover:shadow-glow text-zinc-950 cursor-pointer',
+    inactive: 'bg-zinc-950 hover:shadow-glow text-[--moonlight-red] cursor-pointer',
     unavailable: 'opacity-50 text-[--moonlight-red] cursor-not-allowed',
   }
 

--- a/src/components/Heart.astro
+++ b/src/components/Heart.astro
@@ -1,0 +1,27 @@
+<!-- Wrap the component elements in a custom element “mu-heart” -->
+<mu-heart>
+  <button aria-label="Heart">💜</button> × <span>0</span>
+</mu-heart>
+
+<script>
+  // Define the behaviour for this new type of HTML element
+  // See: https://docs.astro.build/en/guides/client-side-scripts/#web-components-with-custom-elements
+  // WARN: Outside styles like tailwind's aren't available in the shadow DOM by default
+  class Heart extends HTMLElement {
+    connectedCallback() {
+      let count = 0
+
+      const heartButton = this.querySelector('button')!
+      const countSpan = this.querySelector('span')!
+
+      // Each time the button is clicked, update the count.
+      heartButton.addEventListener('click', () => {
+        count++
+        countSpan.textContent = count.toString()
+      })
+    }
+  }
+
+  // Tell the browser to use this Heart class for <mu-heart> elements.
+  customElements.define('mu-heart', Heart)
+</script>

--- a/src/pages/notes.astro
+++ b/src/pages/notes.astro
@@ -35,13 +35,9 @@ const allTags = data?.tags || { valid: [], filtered: [], all: [] }
   } from '../actions/filterNotes/generateNotesPageHtml'
   import type { FilteredNotes } from '../actions/filterNotes'
 
-  const getFilteredNotes = async (tags: string[]): Promise<FilteredNotes | null> => {
+  const getFilteredNotes = async (tags: string[]): Promise<FilteredNotes | undefined> => {
     const { data, error } = await actions.filterNotes({ tags })
-
-    if (error) {
-      console.error(error)
-      return null
-    }
+    if (error) console.error(error)
 
     return data
   }
@@ -55,29 +51,21 @@ const allTags = data?.tags || { valid: [], filtered: [], all: [] }
     const url = new URL(window.location.href)
 
     if (!tags.length) {
-      // Remove the tags parameter from the URL
-      url.searchParams.delete('tags')
+      url.searchParams.delete('tags') // remove the tags param from the URL
     } else {
-      // Manually add the tags as an unencoded comma-separated list
-      url.search = `tags=${tags.sort().join(',')}`
+      url.search = `tags=${tags.sort().join(',')}` // add the tags as an unencoded comma-separated list
     }
 
     window.history.pushState({}, '', url)
   }
 
-  const updateTagCloudHtml = (
-    tagsInUrl: string[],
-    tagsInFilteredEntries: string[],
-    tagsInAllEntries: string[],
-  ): void => {
+  const updateTagCloudHtml = (tags: FilteredNotes['tags']): void => {
     const tagCloud = document.querySelector('ul[data-tag-cloud]')!
-
-    tagCloud.innerHTML = generateTagCloudItemHtml(tagsInUrl, tagsInFilteredEntries, tagsInAllEntries)
+    tagCloud.innerHTML = generateTagCloudItemHtml(tags.valid, tags.filtered, tags.all)
   }
 
   const updateNotesListHtml = (data: NotesListItem[]): void => {
     const notesList = document.querySelector('ul[data-notes-list]')!
-
     notesList.innerHTML = generateNotesListItemHtml(data)
   }
 
@@ -87,7 +75,7 @@ const allTags = data?.tags || { valid: [], filtered: [], all: [] }
     if (filteredNotes) {
       const { results, tags } = filteredNotes
       updateTagsInUrl(tags.valid)
-      updateTagCloudHtml(tags.valid, tags.filtered, tags.all)
+      updateTagCloudHtml(tags)
       updateNotesListHtml(results)
       attachTagButtonEventListeners()
     }
@@ -99,9 +87,9 @@ const allTags = data?.tags || { valid: [], filtered: [], all: [] }
       const tagsInUrl = getTagsFromUrl()
 
       // If the tag is already in the URL, remove it; otherwise append it
+      // TODO: use set operations?
       const newTagsInUrl = tagsInUrl.includes(tag) ? tagsInUrl.filter(t => t !== tag) : [...tagsInUrl, tag]
 
-      // Otherwise, add the tag to the URL and update the notes list
       updateUrlAndDOM(newTagsInUrl)
     }
 

--- a/src/pages/notes.astro
+++ b/src/pages/notes.astro
@@ -1,18 +1,28 @@
 ---
+import { actions } from 'astro:actions'
+import { generateTagCloudItemHtml } from '../actions/filterNotes/generateNotesPageHtml'
 import Main from '../layouts/Main.astro'
+import { generateNotesListItemHtml } from '../actions/filterNotes/generateNotesPageHtml'
+
+// At build time (when URL query params are not available), fetch all notes and their tags and prerender them
+const { data, error } = await Astro.callAction(actions.filterNotes, { tags: [] })
+if (error) console.error(error)
+
+const allEntries = data?.results || []
+const allTags = data?.tags || { valid: [], filtered: [], all: [] }
 ---
 
 <Main title="Notes" description="Rough notes about coding and other topics.">
   <h1 class="sr-only">Notes</h1>
 
   <section>
-    <h2 class="sr-only">Bookmarks, post drafts and topic notes, filterable by tag</h2>
-
-    <!-- Tag cloud -->
-    <ul data-tag-cloud class="flex flex-wrap gap-2"></ul>
-
-    <!-- Bookmarks, post drafts and topic notes by last modified date -->
-    <ul data-notes-list class="mt-5 leading-loose"></ul>
+    <h2 class="sr-only">Bookmarks, post drafts and topic notes (sorted by last modified date and filterable by tag)</h2>
+    <ul
+      data-tag-cloud
+      set:html={generateTagCloudItemHtml(allTags.valid, allTags.filtered, allTags.all)}
+      class="flex flex-wrap gap-2"
+    />
+    <ul data-notes-list set:html={generateNotesListItemHtml(allEntries)} class="mt-5 leading-loose" />
   </section>
 </Main>
 


### PR DESCRIPTION
## What

- Prerenders the tag cloud and results on `/notes/`
- Uses the glow effect on tag button hover instead of a solid bg color
- Makes the inline script logic more concise

## Why

- UX is better when visiting `/notes/` with no tags param (the default) if all the content is ready with no delay (instead of looking at any empty page for a second or two)
- UX is better when hovering with the glow pattern since a solid background now only means "active" (as opposed to "active or you're hovering")
- DX is better the shorter the direct DOM-manipulation code looks (since it's not my preference in general)