### PR TITLE
Better related lists

### DIFF
--- a/src/actions/filterNotes/index.ts
+++ b/src/actions/filterNotes/index.ts
@@ -3,7 +3,14 @@ import { z } from 'astro:schema'
 
 import { getBookmarks } from '../../utils/bookmarks'
 import { getNotes } from '../../utils/notes'
-import { sortByLastModifiedDate, type Bookmark, type Draft, type Note, type Post } from '../../utils/collections'
+import {
+  sortByLastModifiedDate,
+  type Bookmark,
+  type Draft,
+  type Note,
+  type Post,
+  type SinglePage,
+} from '../../utils/collections'
 import { cleanTags, filterItemsByTags, getAllTagsInItems } from '../../utils/tags'
 import type { NotesListItem } from './generateNotesPageHtml'
 import { getDrafts } from '../../utils/drafts'
@@ -59,15 +66,14 @@ const getAccessibleEmojiMarkup = (emoji: string): string => {
   return `<span role="img" aria-label="${getEmojiDescription(emoji)}">${emoji}</span>`
 }
 
-// TODO: return just the content string and let the frontend render it as html?
-const getIconHtml = (item: NotesPageEntry): string => {
+export const getIconHtml = (item: NotesPageEntry | Post | Draft | Note | Bookmark | SinglePage): string => {
   if (item.collection === 'drafts') {
     return getAccessibleEmojiMarkup('✍️')
   }
 
   if (item.collection === 'bookmarks') {
     if (item.data.favicon) {
-      return `<img src="${item.data.favicon}" alt="" width="20" class="inline-block -mt-1 mr-[0.15rem] ml-[0.2rem]" />`
+      return `<img src="${item.data.favicon}" alt="" width="20" class="inline-block !-mt-[0.2rem] !mb-0 mr-[0.15rem] ml-[0.2rem]" />`
     }
 
     if (item.data.source) {

--- a/src/components/Related.astro
+++ b/src/components/Related.astro
@@ -55,6 +55,7 @@ const displayedIds = new Set()
             <ul>
               {tagEntries.map(entry => {
                 if (displayedIds.has(entry.id)) return null
+                const author = 'author' in entry.data ? entry.data.author : null
                 displayedIds.add(entry.id)
 
                 return (
@@ -62,6 +63,12 @@ const displayedIds = new Set()
                     <a href={`/${entry.id}/`} class="link-nav">
                       {entry.data.title}
                     </a>
+                    {author ? (
+                      <>
+                        <span class="mx-1 text-[--moonlight-red]">•</span>
+                        <span class="text-zinc-400">{author}</span>
+                      </>
+                    ) : null}
                     <span class="ml-1" set:html={getIconHtml(entry)} />
                   </li>
                 )

--- a/src/components/Related.astro
+++ b/src/components/Related.astro
@@ -3,7 +3,7 @@ import { type Bookmark, type Draft, type Note, type Post } from '../utils/collec
 import { getNotes } from '../utils/notes'
 import { getPosts } from '../utils/posts'
 import { getBookmarks } from '../utils/bookmarks'
-import { getAllEntriesWithSameTagsAsEntry } from '../utils/tags'
+import { cleanTags, getAllEntriesWithSameTagsAsEntry } from '../utils/tags'
 import { getDrafts } from '../utils/drafts'
 import { getIconHtml } from '../actions/filterNotes'
 
@@ -31,6 +31,8 @@ const tagsInDisplayOrder = Object.keys(entriesWithSameTags).sort((a, b) => {
   return 0
 })
 
+const primaryTag = cleanTags(entry.data.tags)[0]
+
 // Used below to avoid displaying the same entry twice under different tags
 const displayedIds = new Set()
 ---
@@ -47,7 +49,8 @@ const displayedIds = new Set()
         return (
           <section>
             <h2 class="text-red-500">
-              Related to <span class="text-zinc-400">#{tag}</span>
+              <span class="capitalize">{tag === primaryTag ? 'General' : tag}</span>
+              {/* Related to <span class="text-zinc-400">#{tag}</span> */}
             </h2>
             <ul>
               {tagEntries.map(entry => {

--- a/src/components/Related.astro
+++ b/src/components/Related.astro
@@ -1,5 +1,5 @@
 ---
-import { type Bookmark, type Draft, type Note, type Post, type SinglePage } from '../utils/collections'
+import { type Bookmark, type Draft, type Note, type Post } from '../utils/collections'
 import { getNotes } from '../utils/notes'
 import { getPosts } from '../utils/posts'
 import { getBookmarks } from '../utils/bookmarks'
@@ -8,7 +8,7 @@ import { getDrafts } from '../utils/drafts'
 import { getIconHtml } from '../actions/filterNotes'
 
 type Props = {
-  entry: Post | Draft | Note | Bookmark | SinglePage
+  entry: Post | Draft | Note | Bookmark
 }
 
 const { entry } = Astro.props

--- a/src/components/Related.astro
+++ b/src/components/Related.astro
@@ -5,6 +5,7 @@ import { getPosts } from '../utils/posts'
 import { getBookmarks } from '../utils/bookmarks'
 import { getAllEntriesWithSameTagsAsEntry } from '../utils/tags'
 import { getDrafts } from '../utils/drafts'
+import { getIconHtml } from '../actions/filterNotes'
 
 type Props = {
   entry: Post | Draft | Note | Bookmark | SinglePage
@@ -33,13 +34,10 @@ const hasRelatedEntries = Object.keys(entriesWithSameTags).length > 0
           <ul>
             {entriesWithTag.map(entry => (
               <li>
-                <a href={`/${entry.id}/`}>{entry.data.title}</a>
-
-                {/* {'date' in entry.data && entry.data.date ? (
-                  <time datetime={getMachineReadableDate(entry.data.date)} class="timestamp ml-3">
-                    {getHumanReadableDate(entry.data.date)}
-                  </time>
-                ) : null} */}
+                <a href={`/${entry.id}/`} class="link-nav">
+                  {entry.data.title}
+                </a>
+                <span class="ml-1" set:html={getIconHtml(entry)} />
               </li>
             ))}
           </ul>

--- a/src/components/Related.astro
+++ b/src/components/Related.astro
@@ -21,28 +21,52 @@ const entriesWithSameTags = getAllEntriesWithSameTagsAsEntry(entry, [
 ])
 
 const hasRelatedEntries = Object.keys(entriesWithSameTags).length > 0
+
+const tagsInDisplayOrder = Object.keys(entriesWithSameTags).sort((a, b) => {
+  // "introduction" first; first tag in entry.data.tags (i.e. the primary tag) second; everything else in alphabetical order:
+  if (a === 'introduction') return -1
+  if (b === 'introduction') return 1
+  if (entry.data.tags?.includes(a)) return -1
+  if (entry.data.tags?.includes(b)) return 1
+  return 0
+})
+
+// Used below to avoid displaying the same entry twice under different tags
+const displayedIds = new Set()
 ---
 
 {
   hasRelatedEntries ? (
     <footer class="markdown mt-12 border-t-[1px] border-zinc-600 ">
-      {Object.entries(entriesWithSameTags).map(([tag, entriesWithTag]) => (
-        <>
-          <h2 class="text-red-500">
-            Related to <span class="text-zinc-400">#{tag}</span>
-          </h2>
-          <ul>
-            {entriesWithTag.map(entry => (
-              <li>
-                <a href={`/${entry.id}/`} class="link-nav">
-                  {entry.data.title}
-                </a>
-                <span class="ml-1" set:html={getIconHtml(entry)} />
-              </li>
-            ))}
-          </ul>
-        </>
-      ))}
+      {tagsInDisplayOrder.map(tag => {
+        const tagEntries = entriesWithSameTags[tag]
+
+        if (tagEntries.length === 0) return null
+        if (tagEntries.every(entry => displayedIds.has(entry.id))) return null
+
+        return (
+          <section>
+            <h2 class="text-red-500">
+              Related to <span class="text-zinc-400">#{tag}</span>
+            </h2>
+            <ul>
+              {tagEntries.map(entry => {
+                if (displayedIds.has(entry.id)) return null
+                displayedIds.add(entry.id)
+
+                return (
+                  <li>
+                    <a href={`/${entry.id}/`} class="link-nav">
+                      {entry.data.title}
+                    </a>
+                    <span class="ml-1" set:html={getIconHtml(entry)} />
+                  </li>
+                )
+              })}
+            </ul>
+          </section>
+        )
+      })}
     </footer>
   ) : null
 }

--- a/src/layouts/Writing.astro
+++ b/src/layouts/Writing.astro
@@ -15,6 +15,7 @@ import Comments from '../components/Comments.astro'
 import Disclaimer from '../components/Disclaimer.astro'
 import PrevNext from '../components/PrevNext.astro'
 import { isDraft } from '../utils/drafts'
+import { isSinglePage } from '../utils/pages'
 
 type Props = {
   entry: PostWithContent | Post | Draft | Note | Bookmark | SinglePage
@@ -39,7 +40,7 @@ const ogImage = 'ogImage' in entry.data ? (entry.data.ogImage ?? undefined) : un
 const showDate = date && (isPost(entry) || isDraft(entry))
 const showLastModifiedDate = showDate && lastModified && hasBeenModified
 const showComments = isPost(entry)
-const showRelated = !isPost(entry)
+const showRelated = !isPost(entry) && !isSinglePage(entry)
 
 export const maxWidthOfCopy = 'max-w-[72ch]'
 

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -43,22 +43,27 @@ export const getAllEntriesWithSameTagsAsEntry = <T extends Post | Draft | Note |
   entry: T,
   collections: T[],
 ): Record<string, T[]> => {
+  const relatedEntries: Set<T> = new Set()
   const relatedByTag: Record<string, T[]> = {}
 
+  // Find all entries that share at least one tag with the current entry
   for (const item of collections) {
-    // Go in order of the entry's tags, which are presumably sorted from most to least relevant
     for (const tag of cleanTags(entry.data.tags ?? [])) {
       if ((item.data.tags ?? []).includes(tag)) {
-        if (item.id === entry.id) {
-          continue
+        if (item.id !== entry.id) {
+          relatedEntries.add(item)
         }
-
-        if (!relatedByTag[tag]) {
-          relatedByTag[tag] = []
-        }
-
-        relatedByTag[tag].push(item)
       }
+    }
+  }
+
+  for (const entry of relatedEntries) {
+    for (const tag of cleanTags(entry.data.tags ?? [])) {
+      if (!relatedByTag[tag]) {
+        relatedByTag[tag] = []
+      }
+
+      relatedByTag[tag].push(entry)
     }
   }
 

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -1,4 +1,4 @@
-import type { Bookmark, Draft, Note, Post, SinglePage } from './collections'
+import type { Bookmark, Draft, Note, Post } from './collections'
 
 type HasTags = {
   tags?: string[] | null
@@ -36,10 +36,16 @@ export const filterItemsByTags = <T extends HasTags>(items: T[], tags: string[])
   })
 }
 
+type HasDate = {
+  data: {
+    date: Date
+  }
+}
+
 /**
  * Returns a mapping of the entry's tags to lists of other content entries with that tag.
  */
-export const getAllEntriesWithSameTagsAsEntry = <T extends Post | Draft | Note | Bookmark | SinglePage>(
+export const getAllEntriesWithSameTagsAsEntry = <T extends Post | Draft | Note | Bookmark>(
   entry: T,
   collections: T[],
 ): Record<string, T[]> => {
@@ -65,6 +71,21 @@ export const getAllEntriesWithSameTagsAsEntry = <T extends Post | Draft | Note |
 
       relatedByTag[tag].push(entry)
     }
+  }
+
+  for (const tag in relatedByTag) {
+    // Separate items with dates from those without dates
+    const itemsWithDate = relatedByTag[tag].filter(item => 'date' in item.data && item.data.date) as (T & HasDate)[]
+    const itemsWithoutDate = relatedByTag[tag].filter(item => !('date' in item.data) || !item.data.date)
+
+    // Sort items with dates by date (descending)
+    itemsWithDate.sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
+
+    // Sort items without dates by lastModified date (descending)
+    itemsWithoutDate.sort((a, b) => new Date(b.data.lastModified).getTime() - new Date(a.data.lastModified).getTime())
+
+    // Concatenate the sorted arrays
+    relatedByTag[tag] = [...itemsWithDate, ...itemsWithoutDate]
   }
 
   return relatedByTag


### PR DESCRIPTION
## What

- Improves the grouping, sorting and UX of the list of links that appear on draft, note and bookmark pages
- See commit messages for details

## Why

- Making these lists easier to use (and nicer to look at) will help reinforce the plan to take atomic notes and then find related notes by searching and filtering by tags
- The body of the notes pages will be automatically populated by links to other pages related by tag